### PR TITLE
Remove Yurei project references from scripts and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,6 @@ sshpass -p "password" ssh yurei@10.0.0.229 \
 
 ### Notes
 - Use `KODAMA_KEY_PATH=/home/yurei/kodama/camera.key` (default `/var/lib/kodama/camera.key` requires root)
-- A `yurei` service may be running and holding the camera - stop it first:
-  ```bash
-  ssh yurei@10.0.0.229 "sudo systemctl stop yurei"
-  # or
-  ssh yurei@10.0.0.229 "sudo pkill -f '/usr/local/bin/yurei'"
-  ```
 - GPS requires `gpsd` service running with `/dev/ttyUSB1` and GPS enabled on the SIM7600 modem via ModemManager (handled by `kodama-gps.service`)
 
 ## Architecture

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -54,9 +54,7 @@ check_connection() {
 
 stop_camera() {
     echo "Stopping camera..."
-    pi_ssh "sudo systemctl stop yurei 2>/dev/null || true"
     pi_ssh "sudo pkill -f '[k]odama-camera' 2>/dev/null || true"
-    pi_ssh "sudo pkill -f '/usr/local/bin/yurei' 2>/dev/null || true"
 }
 
 build_and_deploy() {


### PR DESCRIPTION
Cleaned up legacy references to the old Yurei project service/executable that are no longer relevant. The Pi image no longer has these artifacts.

Changes:
- Removed systemctl stop yurei and pkill yurei commands from stop_camera() in scripts/pi.sh
- Removed documentation about stopping yurei service from CLAUDE.md

Note: Preserved all references to "yurei" as the Pi username.

https://claude.ai/code/session_016UjTdZHdnG7FJAd9xTHJzn