### PR TITLE
security: Reduce MAX_FRAME_PAYLOAD_SIZE from 16 MB to 2 MB

### DIFF
--- a/crates/kodama-core/src/protocol.rs
+++ b/crates/kodama-core/src/protocol.rs
@@ -14,5 +14,5 @@ pub const DEFAULT_SERVER_PORT: u16 = 7879;
 /// Frame header size in bytes (source + channel + flags + timestamp)
 pub const FRAME_HEADER_SIZE: usize = 8 + 1 + 1 + 8; // 18 bytes
 
-/// Maximum frame payload size (16 MB, generous for high-bitrate video)
-pub const MAX_FRAME_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
+/// Maximum frame payload size (2 MB, sufficient for 4K H.264 keyframes)
+pub const MAX_FRAME_PAYLOAD_SIZE: usize = 2 * 1024 * 1024;


### PR DESCRIPTION
## Summary
- Reduces `MAX_FRAME_PAYLOAD_SIZE` from 16 MB to 2 MB (8x reduction)
- 2 MB is still generous — even 4K H.264 keyframes rarely exceed 1 MB at reasonable bitrates
- Reduces worst-case per-frame memory allocation from a malicious or misbehaving peer

Partial fix for #8 (per-connection rate limiting is still outstanding).

## Test plan
- [x] All 66 workspace tests pass
- [x] Verified `write_frame` and `read_frame` both enforce the limit via `MAX_FRAME_PAYLOAD_SIZE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)