### PR TITLE
fix(ci): install libasound2-dev for ALSA audio build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
     - name: Pin crypto dependencies
       run: |
         cargo update -p sha2 --precise 0.11.0-rc.4 || \

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
       - name: Pin crypto dependencies
         run: |
           cargo update -p sha2 --precise 0.11.0-rc.4 || cargo update -p sha2@0.11.0-rc.4 --precise 0.11.0-rc.4 || true


### PR DESCRIPTION
## Summary
- Install `libasound2-dev` on Ubuntu CI runners so `alsa-sys` (required by `cpal`) can build
- Fix applied to both `ci.yml` (workspace build/test) and `release-server.yml` (Linux server release build)

This resolves the build failures on main since Feb 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)